### PR TITLE
[Handlers] getParent() and isRoot()

### DIFF
--- a/src/Handler/BaseHandler.php
+++ b/src/Handler/BaseHandler.php
@@ -93,6 +93,14 @@ abstract class BaseHandler implements HandlerInterface
     /**
      * {@inheritdoc}
      */
+    public function getParent()
+    {
+        return new Directory($this->filesystem, $this->getDirname());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getExtension()
     {
         return pathinfo($this->path, PATHINFO_EXTENSION);

--- a/src/Handler/Directory.php
+++ b/src/Handler/Directory.php
@@ -12,6 +12,14 @@ class Directory extends BaseHandler implements DirectoryInterface
     /**
      * {@inheritdoc}
      */
+    public function isRoot()
+    {
+        return $this->path === '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function create()
     {
         $this->filesystem->createDir($this->path);

--- a/src/Handler/DirectoryInterface.php
+++ b/src/Handler/DirectoryInterface.php
@@ -13,6 +13,13 @@ use Bolt\Filesystem\Finder;
 interface DirectoryInterface extends HandlerInterface
 {
     /**
+     * Returns whether this directory is the root directory.
+     *
+     * @return bool
+     */
+    public function isRoot();
+
+    /**
      * Create the directory.
      *
      * @throws IOException

--- a/src/Handler/HandlerInterface.php
+++ b/src/Handler/HandlerInterface.php
@@ -49,6 +49,17 @@ interface HandlerInterface extends MountPointAwareInterface
     public function getFullPath();
 
     /**
+     * Returns the directory for this entree.
+     *
+     * Note: If this entree is the root directory, a different
+     * instance of the same directory is returned.
+     * This can also be checked with {@see DirectoryInterface::isRoot}
+     *
+     * @return DirectoryInterface
+     */
+    public function getParent();
+
+    /**
      * Returns whether the entree exists.
      *
      * @return bool


### PR DESCRIPTION
Added `HandlerInterface::getParent` to retrieve the parent directory.
Added `DirectoryInterface::isRoot` to determine if the directory is the root directory.
