### PR TITLE
Image Info caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/finder": "^2.7|^3.0"
     },
     "require-dev": {
+        "doctrine/cache": "^1.6",
         "league/flysystem-memory": "^1.0",
         "league/flysystem-cached-adapter": "^1.0",
         "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,8 @@
         "symfony/finder": "^2.7|^3.0"
     },
     "require-dev": {
+        "league/flysystem-memory": "^1.0",
+        "league/flysystem-cached-adapter": "^1.0",
         "phpunit/phpunit": "^4.8",
         "symfony/filesystem": "^2.7|^3.0"
     },

--- a/src/Adapter/Cached.php
+++ b/src/Adapter/Cached.php
@@ -3,16 +3,85 @@
 namespace Bolt\Filesystem\Adapter;
 
 use Bolt\Filesystem\Capability;
+use Bolt\Filesystem\Exception\IOException;
+use Bolt\Filesystem\Handler\Image;
 use Bolt\Filesystem\Exception\NotSupportedException;
+use League\Flysystem\AdapterInterface;
 use League\Flysystem\Cached\CachedAdapter;
+use League\Flysystem\Cached\CacheInterface;
 
 /**
- * Cached adapter that supports including files.
+ * Cached adapter that supports caching image info and including files.
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
-class Cached extends CachedAdapter implements Capability\IncludeFile
+class Cached extends CachedAdapter implements Capability\ImageInfo, Capability\IncludeFile
 {
+    /** @var CacheInterface */
+    protected $cache;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(AdapterInterface $adapter, CacheInterface $cache)
+    {
+        parent::__construct($adapter, $cache);
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImageInfo($path)
+    {
+        // If cache doesn't support image info, just pass through to adapter.
+        if (!$this->cache instanceof Capability\ImageInfo) {
+            return $this->doGetImageInfo($path);
+        }
+
+        // Get from cache.
+        $info = $this->cache->getImageInfo($path);
+        if ($info !== false) {
+            return is_array($info) ? Image\Info::createFromJson($info) : $info;
+        }
+
+        // Else from adapter.
+        $info = $this->doGetImageInfo($path);
+
+        // Save info from adapter.
+        $object = [
+            'path'       => $path,
+            'image_info' => $info,
+        ];
+        $this->cache->updateObject($path, $object, true);
+
+        return $info;
+    }
+
+    /**
+     * Get image info from adapter.
+     *
+     * @param string $path
+     *
+     * @return Image\Info
+     */
+    private function doGetImageInfo($path)
+    {
+        // Get info from adapter if it's capable.
+        $adapter = $this->getAdapter();
+        if ($adapter instanceof Capability\ImageInfo) {
+            return $adapter->getImageInfo($path);
+        }
+
+        // Else fallback to reading image contents and creating info from string.
+        $result = $this->read($path);
+        if ($result === false || !isset($result['contents'])) {
+            throw new IOException('Failed to read file', $path);
+        }
+
+        return Image\Info::createFromString($result['contents']);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/Cached.php
+++ b/src/Adapter/Cached.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Bolt\Filesystem\Adapter;
+
+use Bolt\Filesystem\Capability;
+use Bolt\Filesystem\Exception\NotSupportedException;
+use League\Flysystem\Cached\CachedAdapter;
+
+/**
+ * Cached adapter that supports including files.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Cached extends CachedAdapter implements Capability\IncludeFile
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function includeFile($path, $once = true)
+    {
+        $adapter = $this->getAdapter();
+        if (!$adapter instanceof Capability\IncludeFile) {
+            throw new NotSupportedException('Filesystem does not support including PHP files.', $path);
+        }
+
+        return $adapter->includeFile($path, $once);
+    }
+}

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -5,12 +5,13 @@ namespace Bolt\Filesystem\Adapter;
 use Bolt\Filesystem\Capability;
 use Bolt\Filesystem\Exception\DirectoryCreationException;
 use Bolt\Filesystem\Exception\IncludeFileException;
+use Bolt\Filesystem\Handler\Image;
 use League\Flysystem\Adapter\Local as LocalBase;
 use League\Flysystem\Config;
 use League\Flysystem\Util;
 use Webmozart\PathUtil\Path;
 
-class Local extends LocalBase implements Capability\IncludeFile
+class Local extends LocalBase implements Capability\ImageInfo, Capability\IncludeFile
 {
     /**
      * {@inheritdoc}
@@ -103,6 +104,16 @@ class Local extends LocalBase implements Capability\IncludeFile
         }
 
         return parent::deleteDir($dirname);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImageInfo($path)
+    {
+        $location = $this->applyPathPrefix($path);
+
+        return Image\Info::createFromFile($location);
     }
 
     /**

--- a/src/Adapter/Memory.php
+++ b/src/Adapter/Memory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Bolt\Filesystem\Adapter;
+
+use Bolt\Filesystem\Capability;
+use League\Flysystem\Memory\MemoryAdapter;
+
+/**
+ * Memory adapter that supports including files.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+class Memory extends MemoryAdapter implements Capability\IncludeFile
+{
+    private $includedFiles = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function includeFile($path, $once = true)
+    {
+        if ($once && isset($this->includedFiles[$path])) {
+            return true;
+        }
+
+        $contents = $this->read($path)['contents'];
+        $contents = evalContents($contents);
+
+        $this->includedFiles[$path] = true;
+
+        return $contents;
+    }
+}
+
+/**
+ * Scope isolated include.
+ *
+ * Prevents access to $this/self from included files.
+ *
+ * @param string $__data
+ *
+ * @return mixed
+ */
+function evalContents($__data)
+{
+    return eval('?>' . $__data);
+}

--- a/src/Cached/Adapter.php
+++ b/src/Cached/Adapter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Bolt\Filesystem\Cached;
+
+use Bolt\Filesystem\Capability;
+
+class Adapter extends \League\Flysystem\Cached\Storage\Adapter implements Capability\ImageInfo
+{
+    use ImageInfoCacheTrait;
+}

--- a/src/Cached/DoctrineCache.php
+++ b/src/Cached/DoctrineCache.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Bolt\Filesystem\Cached;
+
+use Bolt\Filesystem\Capability;
+use Doctrine\Common\Cache\Cache;
+use League\Flysystem\Cached\Storage\AbstractCache;
+
+class DoctrineCache extends AbstractCache implements Capability\ImageInfo
+{
+    use ImageInfoCacheTrait;
+
+    /** @var Cache */
+    protected $doctrine;
+    /** @var string */
+    protected $key;
+    /** @var int */
+    protected $lifeTime;
+
+    /**
+     * Constructor.
+     *
+     * @param Cache  $cache
+     * @param string $key      storage key
+     * @param int    $lifeTime seconds until cache expiration
+     */
+    public function __construct(Cache $cache, $key = 'flysystem', $lifeTime = 0)
+    {
+        $this->doctrine = $cache;
+        $this->key = $key;
+        $this->lifeTime = $lifeTime;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save()
+    {
+        $contents = $this->getForStorage();
+        $this->doctrine->save($this->key, $contents, $this->lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load()
+    {
+        $contents = $this->doctrine->fetch($this->key);
+        if ($contents !== false) {
+            $this->setFromStorage($contents);
+        }
+    }
+}

--- a/src/Cached/ImageInfoCacheTrait.php
+++ b/src/Cached/ImageInfoCacheTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Bolt\Filesystem\Cached;
+
+use Bolt\Filesystem\Handler\Image;
+
+/**
+ * Added image info getter and update cleanContents to persist it.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+trait ImageInfoCacheTrait
+{
+    /**
+     * @param string $path
+     *
+     * @return Image\Info|array|false
+     */
+    public function getImageInfo($path)
+    {
+        if (isset($this->cache[$path]['image_info'])) {
+            return $this->cache[$path]['image_info'];
+        }
+
+        return false;
+    }
+
+    public function cleanContents(array $contents)
+    {
+        $cachedProperties = array_flip($this->getPersistedProperties());
+
+        foreach ($contents as $path => $object) {
+            if (is_array($object)) {
+                $contents[$path] = array_intersect_key($object, $cachedProperties);
+            }
+        }
+
+        return $contents;
+    }
+
+    protected function getPersistedProperties()
+    {
+        return [
+            'path', 'dirname', 'basename', 'extension', 'filename',
+            'size', 'mimetype', 'visibility', 'timestamp', 'type',
+            'image_info'
+        ];
+    }
+}

--- a/src/Cached/Memory.php
+++ b/src/Cached/Memory.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Bolt\Filesystem\Cached;
+
+use Bolt\Filesystem\Capability;
+
+class Memory extends \League\Flysystem\Cached\Storage\Memory implements Capability\ImageInfo
+{
+    use ImageInfoCacheTrait;
+}

--- a/src/Cached/Psr6Cache.php
+++ b/src/Cached/Psr6Cache.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Bolt\Filesystem\Cached;
+
+use Bolt\Filesystem\Capability;
+
+class Psr6Cache extends \League\Flysystem\Cached\Storage\Psr6Cache implements Capability\ImageInfo
+{
+    use ImageInfoCacheTrait;
+}

--- a/src/Capability/ImageInfo.php
+++ b/src/Capability/ImageInfo.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bolt\Filesystem\Capability;
+
+use Bolt\Filesystem\Exception\IOException;
+use Bolt\Filesystem\Handler\Image;
+
+/**
+ * Support for getting image info.
+ *
+ * @author Carson Full <carsonfull@gmail.com>
+ */
+interface ImageInfo
+{
+    /**
+     * Return the info for an image.
+     *
+     * @param string $path The path to the image.
+     *
+     * @throws IOException
+     *
+     * @return Image\Info
+     */
+    public function getImageInfo($path);
+}

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -661,7 +661,15 @@ class Filesystem implements FilesystemInterface, MountPointAwareInterface
      */
     public function getImageInfo($path)
     {
-        return Handler\Image\Info::createFromString($this->read($path));
+        $path = $this->normalizePath($path);
+        $this->assertPresent($path);
+
+        $adapter = $this->getAdapter();
+        if ($adapter instanceof Capability\ImageInfo) {
+            return $adapter->getImageInfo($path);
+        }
+
+        return Handler\Image\Info::createFromString($this->doRead($path));
     }
 
     /**

--- a/src/FilesystemInterface.php
+++ b/src/FilesystemInterface.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\StreamInterface;
  *
  * @author Carson Full <carsonfull@gmail.com>
  */
-interface FilesystemInterface extends Capability\IncludeFile
+interface FilesystemInterface extends Capability\ImageInfo, Capability\IncludeFile
 {
     /**
      * Check whether a file exists.
@@ -324,17 +324,6 @@ interface FilesystemInterface extends Capability\IncludeFile
      * @return string
      */
     public function getMimeType($path);
-
-    /**
-     * Return the info for an image.
-     *
-     * @param string $path The path to the file.
-     *
-     * @throws IOException
-     *
-     * @return Handler\Image\Info
-     */
-    public function getImageInfo($path);
 
     /**
      * Get a file's visibility (public|private).

--- a/tests/Handler/Image/InfoTest.php
+++ b/tests/Handler/Image/InfoTest.php
@@ -95,4 +95,34 @@ class InfoTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotSame($clone->getExif(), $info->getExif());
     }
+
+    public function testSerialize()
+    {
+        $file = $this->filesystem->getFile('fixtures/images/1-top-left.jpg')->read();
+        $expected = Image\Info::createFromString($file);
+        /** @var Image\Info $actual */
+        $actual = unserialize(serialize($expected));
+
+        $this->assertInstanceOf(Image\Info::class, $actual);
+        $this->assertEquals($expected->getDimensions(), $actual->getDimensions());
+        $this->assertSame($expected->getType(), $actual->getType());
+        $this->assertSame($expected->getBits(), $actual->getBits());
+        $this->assertSame($expected->getChannels(), $actual->getChannels());
+        $this->assertSame($expected->getMime(), $actual->getMime());
+        $this->assertEquals($expected->getExif()->getData(), $actual->getExif()->getData());
+    }
+
+    public function testJsonSerialize()
+    {
+        $file = $this->filesystem->getFile('fixtures/images/1-top-left.jpg')->read();
+        $expected = Image\Info::createFromString($file);
+        $actual = Image\Info::createFromJson(json_decode(json_encode($expected), true));
+
+        $this->assertEquals($expected->getDimensions(), $actual->getDimensions());
+        $this->assertSame($expected->getType(), $actual->getType());
+        $this->assertSame($expected->getBits(), $actual->getBits());
+        $this->assertSame($expected->getChannels(), $actual->getChannels());
+        $this->assertSame($expected->getMime(), $actual->getMime());
+        $this->assertEquals($expected->getExif()->getData(), $actual->getExif()->getData());
+    }
 }

--- a/tests/Handler/Image/InfoTest.php
+++ b/tests/Handler/Image/InfoTest.php
@@ -3,11 +3,9 @@
 namespace Bolt\Filesystem\Tests\Handler\Image;
 
 use Bolt\Filesystem\Adapter\Local;
+use Bolt\Filesystem\Exception\IOException;
 use Bolt\Filesystem\Filesystem;
-use Bolt\Filesystem\Handler\Image\Dimensions;
-use Bolt\Filesystem\Handler\Image\Exif;
-use Bolt\Filesystem\Handler\Image\Info;
-use Bolt\Filesystem\Handler\Image\Type;
+use Bolt\Filesystem\Handler\Image;
 
 /**
  * Tests for Bolt\Filesystem\Image\Info
@@ -29,20 +27,20 @@ class InfoTest extends \PHPUnit_Framework_TestCase
 
     public function testConstruct()
     {
-        $exif = new Exif([]);
-        $type = Type::getById(IMAGETYPE_JPEG);
-        $info = new Info(new Dimensions(1024, 768), $type, 2, 7, 'Marcel Marceau', $exif);
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Info', $info);
+        $exif = new Image\Exif([]);
+        $type = Image\Type::getById(IMAGETYPE_JPEG);
+        $info = new Image\Info(new Image\Dimensions(1024, 768), $type, 2, 7, 'Marcel Marceau', $exif);
+        $this->assertInstanceOf(Image\Info::class, $info);
     }
 
     public function testCreateFromFile()
     {
         $file = dirname(dirname(__DIR__)) . '/fixtures/images/1-top-left.jpg';
-        $info = Info::createFromFile($file);
+        $info = Image\Info::createFromFile($file);
 
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Info', $info);
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Type', $info->getType());
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Exif', $info->getExif());
+        $this->assertInstanceOf(Image\Info::class, $info);
+        $this->assertInstanceOf(Image\Type::class, $info->getType());
+        $this->assertInstanceOf(Image\Exif::class, $info->getExif());
 
         $this->assertSame(400, $info->getWidth());
         $this->assertSame(200, $info->getHeight());
@@ -58,18 +56,18 @@ class InfoTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateFromFileFail()
     {
-        $this->setExpectedException('Bolt\Filesystem\Exception\IOException', 'Failed to get image data from file');
-        Info::createFromFile('drop-bear.jpg');
+        $this->setExpectedException(IOException::class, 'Failed to get image data from file');
+        Image\Info::createFromFile('drop-bear.jpg');
     }
 
     public function testCreateFromString()
     {
-        $file = $this->filesystem->get('fixtures/images/1-top-left.jpg')->read();
-        $info = Info::createFromString($file);
+        $file = $this->filesystem->getFile('fixtures/images/1-top-left.jpg')->read();
+        $info = Image\Info::createFromString($file);
 
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Info', $info);
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Type', $info->getType());
-        $this->assertInstanceOf('Bolt\Filesystem\Handler\Image\Exif', $info->getExif());
+        $this->assertInstanceOf(Image\Info::class, $info);
+        $this->assertInstanceOf(Image\Type::class, $info->getType());
+        $this->assertInstanceOf(Image\Exif::class, $info->getExif());
 
         $this->assertSame(400, $info->getWidth());
         $this->assertSame(200, $info->getHeight());
@@ -85,14 +83,14 @@ class InfoTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateFromStringFail()
     {
-        $this->setExpectedException('Bolt\Filesystem\Exception\IOException', 'Failed to get image data from string');
-        Info::createFromString('drop-bear.jpg');
+        $this->setExpectedException(IOException::class, 'Failed to get image data from string');
+        Image\Info::createFromString('drop-bear.jpg');
     }
 
     public function testClone()
     {
-        $file = $this->filesystem->get('fixtures/images/1-top-left.jpg')->read();
-        $info = Info::createFromString($file);
+        $file = $this->filesystem->getFile('fixtures/images/1-top-left.jpg')->read();
+        $info = Image\Info::createFromString($file);
         $clone = clone $info;
 
         $this->assertNotSame($clone->getExif(), $info->getExif());


### PR DESCRIPTION
Extending Flysystem's `CachedAdapter` to support caching `Image\Info` and including PHP files. Also added `Memory` adapter which supports including PHP files.
