### PR TITLE
[Deprecation] Handle deprecated YAML parameters

### DIFF
--- a/src/Handler/YamlFile.php
+++ b/src/Handler/YamlFile.php
@@ -4,6 +4,7 @@ namespace Bolt\Filesystem\Handler;
 
 use Bolt\Filesystem\Exception\DumpException;
 use Bolt\Filesystem\Exception\ParseException;
+use ReflectionMethod;
 use Symfony\Component\Yaml\Exception as Symfony;
 use Symfony\Component\Yaml\Yaml;
 
@@ -15,6 +16,9 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlFile extends File implements ParsableInterface
 {
+    /** @var bool Whether symfony/yaml is v3.1+ */
+    private static $useFlags;
+
     /**
      * {@inheritdoc}
      */
@@ -27,13 +31,21 @@ class YamlFile extends File implements ParsableInterface
         ];
 
         $contents = $this->read();
+
+        static::checkYamlVersion();
+
         try {
-            return Yaml::parse(
-                $contents,
-                $options['exceptionsOnInvalidType'],
-                $options['objectSupport'],
-                $options['objectForMap']
-            );
+            if (static::$useFlags) {
+                $flags = $this->optionsToFlags($options);
+                return Yaml::parse($contents, $flags);
+            } else {
+                return Yaml::parse(
+                    $contents,
+                    $options['exceptionsOnInvalidType'],
+                    $options['objectSupport'],
+                    $options['objectForMap']
+                );
+            }
         } catch (Symfony\ParseException $e) {
             throw ParseException::castFromYaml($e);
         }
@@ -51,17 +63,60 @@ class YamlFile extends File implements ParsableInterface
             'objectSupport'           => false,
         ];
 
+        static::checkYamlVersion();
+
         try {
-            $contents = Yaml::dump(
-                $contents,
-                $options['inline'],
-                $options['indent'],
-                $options['exceptionsOnInvalidType'],
-                $options['objectSupport']
-            );
+            if (static::$useFlags) {
+                $flags = $this->optionsToFlags($options);
+                $contents = Yaml::dump($contents, $options['inline'], $options['indent'], $flags);
+            } else {
+                $contents = Yaml::dump(
+                    $contents,
+                    $options['inline'],
+                    $options['indent'],
+                    $options['exceptionsOnInvalidType'],
+                    $options['objectSupport']
+                );
+            }
         } catch (Symfony\DumpException $e) {
             throw new DumpException($e->getMessage(), $e->getCode(), $e);
         }
         $this->put($contents);
+    }
+
+    /**
+     * @deprecated Remove when symfony/yaml 3.1+ is required
+     *
+     * @param array $options
+     *
+     * @return int
+     */
+    private function optionsToFlags(array $options)
+    {
+        $flagParams = [
+            'exceptionsOnInvalidType' => Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE,
+            'objectSupport'           => Yaml::PARSE_OBJECT,
+            'objectForMap'            => Yaml::PARSE_OBJECT_FOR_MAP,
+        ];
+
+        $flags = 0;
+        foreach ($flagParams as $optionName => $bit) {
+            if (isset($options[$optionName]) && $options[$optionName]) {
+                $flags |= $bit;
+            }
+        }
+
+        return $flags;
+    }
+
+    /**
+     * @deprecated Remove when symfony/yaml 3.1+ is required
+     */
+    private static function checkYamlVersion()
+    {
+        if (static::$useFlags === null) {
+            $ref = new ReflectionMethod(Yaml::class, 'parse');
+            static::$useFlags = $ref->getNumberOfParameters() === 2;
+        }
     }
 }


### PR DESCRIPTION
Kills off several thousand of these in Bolt when running Symfony YAML 3.1+
```
Passing a boolean flag to toggle exception handling is deprecated since version 3.1 
and will be removed in 4.0. Use the PARSE_EXCEPTION_ON_INVALID_TYPE flag
instead
```