### PR TITLE
Updating travis phpunit binary location to one that works with php7, hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 sudo: false
+dist: trusty
 
 php:
   - 5.5
@@ -14,7 +15,7 @@ matrix:
     - php: hhvm
 
 before_install:
-  
+
 before_script:
   # Set up Composer
   - composer self-update || true
@@ -22,7 +23,7 @@ before_script:
 
 script:
   # PHPUnit
-  - phpunit
+  - vendor/bin/phpunit
 
 after_script:
 


### PR DESCRIPTION
[Currently phpunit is not running tests on the PHP7 environment](https://travis-ci.org/bolt/filesystem/jobs/220147912#L180). This quick patch fixes that.

I also set the target distribution to trusty, [because it seems that hhvm is no longer supported on precise...](https://travis-ci.org/NickWer/filesystem/jobs/237664168#L134) 