### PR TITLE
Correctly delete target mirroring across mounts

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -336,9 +336,9 @@ class Manager implements AggregateFilesystemInterface, FilesystemInterface
                 $origin = str_replace($targetDir, $originDir, $handler->getPath());
                 if (!$fsOrigin->has($origin)) {
                     if ($handler->isDir()) {
-                        $fsTarget->deleteDir($origin);
+                        $fsTarget->deleteDir($handler->getPath());
                     } else {
-                        $fsTarget->delete($origin);
+                        $fsTarget->delete($handler->getPath());
                     }
                 }
             }


### PR DESCRIPTION
Test case:

1. Add a file to target that doesn't exist in origin
2. Call:
```php
$origin = 'root://deep/path/directory/to/mirror/';
$target = 'web://shallow/path/';
$app['filesystem']->mirror($origin, $target);
```

Result:

```
 [Bolt\Filesystem\Exception\FileNotFoundException]              
  File not found at path: shallow/path/file-to-delete.ext  
```