### PR TITLE
Update JSON to use bolt/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "bolt/common": "^1.0",
         "ext-json": "*",
         "guzzlehttp/psr7": "^1.2",
         "league/flysystem": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "nesbot/carbon": "^1.20",
         "php": "^5.5.9 || ^7.0",
         "webmozart/glob": "^4.0",
-        "seld/jsonlint": "^1.4",
         "symfony/finder": "^2.7|^3.0",
         "symfony/yaml": "^2.7|^3.0"
     },

--- a/src/Exception/DumpException.php
+++ b/src/Exception/DumpException.php
@@ -2,6 +2,6 @@
 
 namespace Bolt\Filesystem\Exception;
 
-class DumpException extends RuntimeException
+class DumpException extends \Bolt\Common\Exception\DumpException implements ExceptionInterface
 {
 }

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -2,35 +2,21 @@
 
 namespace Bolt\Filesystem\Exception;
 
-use Seld\JsonLint\ParsingException as JsonParseException;
 use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
 
-class ParseException extends RuntimeException
+class ParseException extends \Bolt\Common\Exception\ParseException implements ExceptionInterface
 {
-    /** @var int */
-    private $parsedLine;
-    /** @var string|null */
-    private $snippet;
-    /** @var string */
-    private $rawMessage;
-
     /**
      * Constructor.
      *
      * @param string      $message    The error message
      * @param int         $parsedLine The line where the error occurred
      * @param null|string $snippet    The snippet of code near the problem
-     * @param \Exception  $previous   The previous exception
+     * @param \Throwable  $previous   The previous exception
      */
-    public function __construct($message, $parsedLine = -1, $snippet = null, \Exception $previous = null)
+    public function __construct($message, $parsedLine = -1, $snippet = null, $previous = null)
     {
-        $this->parsedLine = $parsedLine;
-        $this->snippet = $snippet;
-        $this->rawMessage = $message;
-
-        $this->updateRepr();
-
-        parent::__construct($this->message, 0, $previous);
+        parent::__construct($message, $parsedLine, $snippet, $previous ? $previous->getCode() : 0, $previous);
     }
 
     /**
@@ -45,107 +31,6 @@ class ParseException extends RuntimeException
         $message = static::parseRawMessage($exception->getMessage());
 
         return new static($message, $exception->getParsedLine(), $exception->getSnippet(), $exception);
-    }
-
-    /**
-     * Casts JsonLint ParseException to ours.
-     *
-     * @param JsonParseException $exception
-     *
-     * @return ParseException
-     */
-    public static function castFromJson(JsonParseException $exception)
-    {
-        $details = $exception->getDetails();
-        $message = $exception->getMessage();
-        $line = isset($details['line']) ? $details['line'] : -1;
-        $snippet = null;
-
-        if (preg_match("/^Parse error on line (?<line>\\d+):\n(?<snippet>.+)\n.+\n(?<message>.+)$/", $message, $matches)) {
-            $line = (int) $matches[1];
-            $snippet = $matches[2];
-            $message = $matches[3];
-        }
-
-        $trailingComma = false;
-        $pos = strpos($message, ' - It appears you have an extra trailing comma');
-        if ($pos > 0) {
-            $message = substr($message, 0, $pos);
-            $trailingComma = true;
-        }
-
-        if (strpos($message, 'Expected') === 0 && $trailingComma) {
-            $message = 'It appears you have an extra trailing comma';
-        }
-
-        return new static($message, $line, $snippet);
-    }
-
-    /**
-     * Gets the line where the error occurred.
-     *
-     * @return int The file line
-     */
-    public function getParsedLine()
-    {
-        return $this->parsedLine;
-    }
-
-    /**
-     * Sets the line where the error occurred.
-     *
-     * @param int $parsedLine The file line
-     */
-    public function setParsedLine($parsedLine)
-    {
-        $this->parsedLine = $parsedLine;
-
-        $this->updateRepr();
-    }
-
-    /**
-     * Gets the snippet of code near the error.
-     *
-     * @return string The snippet of code
-     */
-    public function getSnippet()
-    {
-        return $this->snippet;
-    }
-
-    /**
-     * Sets the snippet of code near the error.
-     *
-     * @param string $snippet The code snippet
-     */
-    public function setSnippet($snippet)
-    {
-        $this->snippet = $snippet;
-
-        $this->updateRepr();
-    }
-
-    private function updateRepr()
-    {
-        $this->message = $this->rawMessage;
-
-        $dot = false;
-        if ('.' === substr($this->message, -1)) {
-            $this->message = substr($this->message, 0, -1);
-            $dot = true;
-        }
-
-        if ($this->parsedLine >= 0) {
-            $this->message .= sprintf(' at line %d', $this->parsedLine);
-        }
-
-        if ($this->snippet) {
-            $this->message .= sprintf(' (near "%s")', $this->snippet);
-        }
-
-        if ($dot) {
-            $this->message .= '.';
-        }
     }
 
     /**

--- a/src/Handler/JsonFile.php
+++ b/src/Handler/JsonFile.php
@@ -2,7 +2,9 @@
 
 namespace Bolt\Filesystem\Handler;
 
-use Bolt\Filesystem\Json;
+use Bolt\Common\Json;
+use Bolt\Filesystem\Exception\DumpException;
+use Bolt\Filesystem\Exception\ParseException;
 
 /**
  * File handling for JSON files.
@@ -24,7 +26,11 @@ class JsonFile extends File implements ParsableInterface
 
         $contents = $this->read();
 
-        return Json::parse($contents, $options['depth'], $options['flags']);
+        try {
+            return Json::parse($contents, $options['flags'], $options['depth']);
+        } catch (\Bolt\Common\Exception\ParseException $e) {
+            throw new ParseException($e->getRawMessage(), $e->getParsedLine(), $e->getSnippet(), $e);
+        }
     }
 
     /**
@@ -36,7 +42,12 @@ class JsonFile extends File implements ParsableInterface
             'flags' => 448,
         ];
 
-        $content = Json::dump($contents, $options['flags']);
+        try {
+            $content = Json::dump($contents, $options['flags']);
+        } catch (\Bolt\Common\Exception\DumpException $e) {
+            throw new DumpException($e->getMessage(), $e->getCode(), $e);
+        }
+
         $this->put($content);
     }
 }


### PR DESCRIPTION
- Updated JSON code to use `Json` class from `bolt/common`.
- Deprecated our `Json` class.
