### PR TITLE
Update miljar/php-exif to ^0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-json": "*",
         "guzzlehttp/psr7": "^1.2",
         "league/flysystem": "^1.0",
-        "miljar/php-exif": "^0.5",
+        "miljar/php-exif": "^0.6",
         "nesbot/carbon": "^1.20",
         "php": "^5.5.9 || ^7.0",
         "webmozart/glob": "^4.0",

--- a/src/Handler/Image/Info.php
+++ b/src/Handler/Image/Info.php
@@ -225,13 +225,13 @@ class Info implements JsonSerializable, Serializable
         if (static::$exifReader === null) {
             static::$exifReader = Reader::factory(Reader::TYPE_NATIVE);
         }
-        try {
-            $exif = static::$exifReader->read($file);
 
+        $exif = static::$exifReader->read($file);
+        if ($exif instanceof \PHPExif\Exif) {
             return Exif::cast($exif);
-        } catch (\RuntimeException $e) {
-            return new Exif();
         }
+
+        return new Exif();
     }
 
     /**

--- a/tests/Handler/Image/InfoTest.php
+++ b/tests/Handler/Image/InfoTest.php
@@ -195,4 +195,15 @@ class InfoTest extends TestCase
         $this->assertTrue($info->isValid());
         $this->assertInstanceOf(Image\SvgType::class, $info->getType());
     }
+
+    public function testReadExif()
+    {
+        $info = Image\Info::createFromFile(__DIR__ . '/../../fixtures2/empty.jpg');
+
+        $m = new \ReflectionMethod(Image\Info::class,'readExif');
+        $m->setAccessible(true);
+
+        $exif = $m->invoke($info, __DIR__ . '/../../fixtures2/empty.jpg');
+        $this->assertInstanceOf(Image\Exif::class, $exif);
+    }
 }


### PR DESCRIPTION
The `miljar/php-exif` repository doesn't use strict SemVer, but we're locked onto 0.5.x. 

c.f. [code changes](https://github.com/PHPExif/php-exif/compare/v0.5.1...v0.6.3)