### PR TITLE
Import @internal ConfigAwareTrait from Flysystem

### DIFF
--- a/src/ConfigAwareTrait.php
+++ b/src/ConfigAwareTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Bolt\Filesystem;
+
+use League\Flysystem\Config;
+use League\Flysystem\Util;
+
+/**
+ * @internal
+ */
+trait ConfigAwareTrait
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * Set the config.
+     *
+     * @param Config|array|null $config
+     */
+    protected function setConfig($config)
+    {
+        $this->config = $config ? Util::ensureConfig($config) : new Config;
+    }
+
+    /**
+     * Get the Config.
+     *
+     * @return Config config object
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
+     * Convert a config array to a Config object with the correct fallback.
+     *
+     * @param array $config
+     *
+     * @return Config
+     */
+    protected function prepareConfig(array $config)
+    {
+        $config = new Config($config);
+        $config->setFallback($this->getConfig());
+
+        return $config;
+    }
+}

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -22,7 +22,7 @@ class Filesystem implements FilesystemInterface, MountPointAwareInterface
 {
     use MountPointAwareTrait;
     use Plugin\PluggableTrait;
-    use Flysystem\ConfigAwareTrait;
+    use ConfigAwareTrait;
 
     /** @var Flysystem\AdapterInterface */
     protected $adapter;


### PR DESCRIPTION
Symfony deprecation handler is now issuing deprecation style warnings in Bolt master as a result that this is being used outside the base library.