### PR TITLE
Add file existence check just before deleting

### DIFF
--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -136,6 +136,22 @@ class Local extends LocalBase implements Capability\ImageInfo, Capability\Includ
             throw new IncludeFileException($e->getMessage(), $path, 0, $e);
         }
     }
+    
+    /**
+     * @inheritdoc
+     */
+    public function getMetadata($path)
+    {
+        $location = $this->applyPathPrefix($path);
+
+        if (!file_exists($location)) {
+            throw new FileNotFoundException($location);
+        }
+
+        $info = new SplFileInfo($location);
+
+        return $this->normalizeFileInfo($info);
+    }
 }
 
 /**

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -152,7 +152,7 @@ class Local extends LocalBase implements Capability\ImageInfo, Capability\Includ
             throw new FileNotFoundException($path);
         }
 
-        $info = new SplFileInfo($location);
+        $info = new \SplFileInfo($location);
 
         return $this->normalizeFileInfo($info);
     }

--- a/src/Adapter/Local.php
+++ b/src/Adapter/Local.php
@@ -66,7 +66,7 @@ class Local extends LocalBase implements Capability\ImageInfo, Capability\Includ
         $location = $this->applyPathPrefix($path);
 
         if (!file_exists($location)) {
-            throw new FileNotFoundException($location);
+            throw new FileNotFoundException($path);
         }
 
         if (!is_writable($location)) {
@@ -76,7 +76,11 @@ class Local extends LocalBase implements Capability\ImageInfo, Capability\Includ
         try {
             return Thrower::call('unlink', $location);
         } catch (\ErrorException $ex) {
-            throw new FileNotFoundException($location, $ex);
+            if (strpos($ex->getMessage(), "No such file or directory") !== false) {
+                throw new FileNotFoundException($path, $ex);
+            } else {
+                throw new IOException('Could not remove file', $path);
+            }
         }
     }
 
@@ -145,7 +149,7 @@ class Local extends LocalBase implements Capability\ImageInfo, Capability\Includ
         $location = $this->applyPathPrefix($path);
 
         if (!file_exists($location)) {
-            throw new FileNotFoundException($location);
+            throw new FileNotFoundException($path);
         }
 
         $info = new SplFileInfo($location);

--- a/tests/Adapter/LocalTest.php
+++ b/tests/Adapter/LocalTest.php
@@ -3,6 +3,7 @@
 namespace Bolt\Filesystem\Tests\Adapter;
 
 use Bolt\Filesystem\Adapter\Local;
+use Bolt\Filesystem\Exception\FileNotFoundException;
 use Bolt\Filesystem\Filesystem;
 use Bolt\Filesystem\FilesystemInterface;
 use Bolt\Filesystem\Tests\FilesystemTestCase;
@@ -58,6 +59,9 @@ class LocalTest extends FilesystemTestCase
         $this->assertFalse($update);
     }
 
+    /**
+     * @expectedException \Bolt\Filesystem\Exception\FileNotFoundException
+     */
     public function testDelete()
     {
         $this->filesystem->get('fixtures/base.css')->copy('temp/koala.css');
@@ -65,8 +69,7 @@ class LocalTest extends FilesystemTestCase
         $delete = $local->delete('koala.css');
         $this->assertTrue($delete);
 
-        $delete = $local->delete('koala.css.typo');
-        $this->assertFalse($delete);
+        $local->delete('koala.css.typo');
     }
 
     public function testCreateDir()


### PR DESCRIPTION
Sometimes code execution is out of sync with the filesystem. Even if you call assertPresent() just before calling delete(), it can get deleted in the middle of execution.

Exception chain:

```
3/3
StorageException in Timer.php line 71:
Unable to remove database schema check timestamp: Warning: unlink(var/cache/dbcheck.ts): No such file or directory

2/3
IOException in Filesystem.php line 819:
Warning: unlink(var/cache/dbcheck.ts): No such file or directory

1/3
ContextErrorException in Local.php line 70:
Warning: unlink(var/cache/dbcheck.ts): No such file or directory
```