### PR TITLE
Fix type of argument passed to the `isSvg` method

### DIFF
--- a/src/Handler/Image/Info.php
+++ b/src/Handler/Image/Info.php
@@ -121,7 +121,7 @@ class Info implements JsonSerializable, Serializable
             return static::createInvalid();
         }
 
-        if (static::isSvg($data, $filename)) {
+        if (static::isSvg($data, (string) $filename)) {
             return static::createSvgFromString($data);
         }
 


### PR DESCRIPTION
The method only accepts string, so let's cast it. Here is not a big issue, but it breaks the code down the line, because the library used is definig strict types.